### PR TITLE
Preparations for reactivating Mender mechanism of persisting the machine ID

### DIFF
--- a/meta-mender-tegra/recipes-bsp/uefi/edk2-firmware-tegra_%.bbappend
+++ b/meta-mender-tegra/recipes-bsp/uefi/edk2-firmware-tegra_%.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI += "file://0001-Enable-runtime-access-to-KernelCommandLine-efivar.patch;patchdir=../edk2-nvidia"

--- a/meta-mender-tegra/recipes-bsp/uefi/files/0001-Enable-runtime-access-to-KernelCommandLine-efivar.patch
+++ b/meta-mender-tegra/recipes-bsp/uefi/files/0001-Enable-runtime-access-to-KernelCommandLine-efivar.patch
@@ -1,0 +1,54 @@
+From 9b2b9fbca52c8979b41722936617696622722ecf Mon Sep 17 00:00:00 2001
+From: Alexander Knaub <alexander.knaub@faro.com>
+Date: Tue, 19 Nov 2024 09:24:56 +0100
+Subject: [PATCH] edk2-nvidia: Enable runtime access to KernelCommandLine
+ efivar
+
+---
+ Silicon/NVIDIA/Drivers/NvidiaConfigDxe/NvidiaConfigDxe.c   | 2 +-
+ Silicon/NVIDIA/Drivers/NvidiaConfigDxe/NvidiaConfigHii.vfr | 2 +-
+ Silicon/NVIDIA/Library/PlatformBootManagerLib/PlatformBm.c | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/Silicon/NVIDIA/Drivers/NvidiaConfigDxe/NvidiaConfigDxe.c b/Silicon/NVIDIA/Drivers/NvidiaConfigDxe/NvidiaConfigDxe.c
+index cd896efc..3b927636 100644
+--- a/Silicon/NVIDIA/Drivers/NvidiaConfigDxe/NvidiaConfigDxe.c
++++ b/Silicon/NVIDIA/Drivers/NvidiaConfigDxe/NvidiaConfigDxe.c
+@@ -1827,7 +1827,7 @@ InitializeSettings (
+   if (KernelCmdLineLen < sizeof (CmdLine)) {
+     KernelCmdLineLen = sizeof (CmdLine);
+     ZeroMem (&CmdLine, KernelCmdLineLen);
+-    Status = gRT->SetVariable (L"KernelCommandLine", &gNVIDIAPublicVariableGuid, EFI_VARIABLE_NON_VOLATILE | EFI_VARIABLE_BOOTSERVICE_ACCESS, KernelCmdLineLen, (VOID *)&CmdLine);
++    Status = gRT->SetVariable (L"KernelCommandLine", &gNVIDIAPublicVariableGuid, EFI_VARIABLE_NON_VOLATILE | EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_RUNTIME_ACCESS, KernelCmdLineLen, (VOID *)&CmdLine);
+     if (EFI_ERROR (Status)) {
+       DEBUG ((DEBUG_ERROR, "%a: Error setting command line variable %r\r\n", __FUNCTION__, Status));
+     }
+diff --git a/Silicon/NVIDIA/Drivers/NvidiaConfigDxe/NvidiaConfigHii.vfr b/Silicon/NVIDIA/Drivers/NvidiaConfigDxe/NvidiaConfigHii.vfr
+index 328b7789..2d196376 100644
+--- a/Silicon/NVIDIA/Drivers/NvidiaConfigDxe/NvidiaConfigHii.vfr
++++ b/Silicon/NVIDIA/Drivers/NvidiaConfigDxe/NvidiaConfigHii.vfr
+@@ -61,7 +61,7 @@ formset
+     guid  = NVIDIA_TOKEN_SPACE_GUID;
+ 
+   efivarstore NVIDIA_KERNEL_COMMAND_LINE,
+-    attribute = EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,  // EFI variable attributes
++    attribute = EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE | EFI_VARIABLE_RUNTIME_ACCESS,  // EFI variable attributes
+     name  = KernelCommandLine,
+     guid  = NVIDIA_PUBLIC_VARIABLE_GUID;
+ 
+diff --git a/Silicon/NVIDIA/Library/PlatformBootManagerLib/PlatformBm.c b/Silicon/NVIDIA/Library/PlatformBootManagerLib/PlatformBm.c
+index b2c69f47..51299d60 100644
+--- a/Silicon/NVIDIA/Library/PlatformBootManagerLib/PlatformBm.c
++++ b/Silicon/NVIDIA/Library/PlatformBootManagerLib/PlatformBm.c
+@@ -1318,7 +1318,7 @@ IsPlatformConfigurationNeeded (
+     AddlCmdLen = sizeof (AddlCmdLine);
+     Status     = gRT->GetVariable (L"KernelCommandLine", &gNVIDIAPublicVariableGuid, &AddlCmdLineAttributes, &AddlCmdLen, &AddlCmdLine);
+     if (EFI_ERROR (Status)) {
+-      AddlCmdLineAttributes = EFI_VARIABLE_NON_VOLATILE | EFI_VARIABLE_BOOTSERVICE_ACCESS;
++      AddlCmdLineAttributes = EFI_VARIABLE_NON_VOLATILE | EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_RUNTIME_ACCESS;
+       ZeroMem (&AddlCmdLine, sizeof (AddlCmdLine));
+     }
+ 
+-- 
+2.34.1
+

--- a/meta-mender-tegra/recipes-mender/mender-client/mender-tegra.inc
+++ b/meta-mender-tegra/recipes-mender/mender-client/mender-tegra.inc
@@ -2,7 +2,7 @@ EXTRADEPS:tegra = "tegra-uefi-capsules libubootenv-fake mender-update-verifier"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 SRC_URI:remove:mender-persist-systemd-machine-id = " \
-    file://mender-client-set-systemd-machine-id.sh \
+    file://mender-set-systemd-machine-id.sh \
 "
 SRC_URI:append:mender-persist-systemd-machine-id = " \
     file://tegra-mender-client-set-systemd-machine-id.sh \
@@ -12,5 +12,5 @@ SRC_URI:append:mender-persist-systemd-machine-id = " \
 do_install:prepend:class-target:mender-persist-systemd-machine-id() {
     install -d -m 755 ${D}${bindir}
     install -m 755 ${WORKDIR}/efi_systemd_machine_id.sh ${D}${bindir}/
-    cp ${WORKDIR}/tegra-mender-client-set-systemd-machine-id.sh ${WORKDIR}/mender-client-set-systemd-machine-id.sh 
+    cp ${WORKDIR}/tegra-mender-client-set-systemd-machine-id.sh ${WORKDIR}/mender-set-systemd-machine-id.sh
 }


### PR DESCRIPTION
* tegra: uefi: Enable runtime access to KernelCommandLine EFI parameter
* Adjust name of set-systemd-machine-id script that is replaced by tegra-specific bbappend